### PR TITLE
Remove versioning in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Contribute](#contribute)
-- [Versioning](#versioning)
 - [Additional information](#additional-information)
 ---
 
@@ -47,16 +46,6 @@ Below you will find a quickstart for the configuration, for a full description p
 ### Contribute
 We really appreciate it when developers contribute to improve the Buckaroo plugins.
 If you want to contribute as well, then please follow our [Contribution Guidelines](CONTRIBUTING.md).
-
-### Versioning 
-<p align="left">
-  <img src="https://www.buckaroo.nl/media/3480/magento_versioning.png" width="500px" position="center">
-</p>
-
-- **MAJOR:** Breaking changes that require additional testing/caution.
-- **MINOR:** Changes that should not have a big impact.
-- **PATCHES:** Bug and hotfixes only.
-
 
 ### Additional information
 - **Support:** https://support.buckaroo.eu/contact


### PR DESCRIPTION
Remove versioning for the former Sisow plugin.